### PR TITLE
Use string.gmatch if string.gfind is not available

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -26,6 +26,8 @@ local function trim(s)
     return s:match("^%s*(.-)%s*$")
 end
 
+local gfind = string.gfind or string.gmatch
+
 local function print_table(t)
     for key, val in pairs(t) do
         print(key, val)
@@ -51,7 +53,7 @@ function split(str, delim)
         return { str }
     end
     local result,pat,lastpos = {},"(.-)" .. delim .. "()",nil
-    for part, pos in string.gfind(str, pat) do
+    for part, pos in gfind(str, pat) do
         table.insert(result, part)
         lastpos = pos
     end


### PR DESCRIPTION
I have problems to run the debugger because of

(TDB) Tarantool debugger v.0.0.3. Type h for help
2017-06-01 16:05:54.348 [5881] main/101/bug.lua F> /usr/share/tarantool/utils.lua:54: attempt to call field 'gfind' (a nil value)

As I can understand from [mailing list](http://lua-users.org/lists/lua-l/2013-04/msg00116.html) gfind function is replaced with gmatch.
